### PR TITLE
Prevent inserting duplicate records into DB

### DIFF
--- a/PornHub/PornHub/pipelines.py
+++ b/PornHub/PornHub/pipelines.py
@@ -6,6 +6,7 @@
 # See: http://doc.scrapy.org/en/latest/topics/item-pipeline.html
 
 import pymongo
+from pymongo import IndexModel, ASCENDING
 from items import PornVideoItem
 
 
@@ -14,6 +15,10 @@ class PornhubMongoDBPipeline(object):
         clinet = pymongo.MongoClient("localhost", 27017)
         db = clinet["PornHub"]
         self.PhRes = db["PhRes"]
+        idx = IndexModel([('link_url', ASCENDING)], unique=True)
+        self.PhRes.create_indexes([idx])
+        # if your existing DB has duplicate records, refer to:
+        # https://stackoverflow.com/questions/35707496/remove-duplicate-in-mongodb/35711737
 
     def process_item(self, item, spider):
         print 'MongoDBItem', item
@@ -21,7 +26,7 @@ class PornhubMongoDBPipeline(object):
         if isinstance(item, PornVideoItem):
             print 'PornVideoItem True'
             try:
-                self.PhRes.insert(dict(item))
+                self.PhRes.update_one({'link_url': item['link_url']}, {'$set': dict(item)}, upsert=True)
             except Exception:
                 pass
         return item


### PR DESCRIPTION
Use `link_url` as unique key. Note that if existing DB already contains duplicate records, you need to manually remove them before running this script.