### PR TITLE
Fix a memory leak issue

### DIFF
--- a/PornHub/PornHub/settings.py
+++ b/PornHub/PornHub/settings.py
@@ -36,3 +36,7 @@ DOWNLOADER_MIDDLEWARES = {
 
 FEED_URI=u'/Users/xiyouMc/Documents/pornhub.csv'
 FEED_FORMAT='CSV'
+
+DEPTH_PRIORITY = 1
+SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'
+SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.FifoMemoryQueue'


### PR DESCRIPTION
Run the current crawler, memory usage is 60+MB at startup. After running for about 1 hour, MEM grows to more than 100MB and keep growing. With this fix, after 10+ hours, MEM usage still below 70MB.